### PR TITLE
Version code changed from 5 to 6 version changed from 1.1.1 to 1.1.2.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,15 +1,15 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
+    compileSdkVersion 26
     buildToolsVersion '26.0.0'
     defaultConfig {
         applicationId "mjt.shopwise"
-        minSdkVersion 16
-        targetSdkVersion 25
-        versionName '1.1.1'
+        minSdkVersion 14
+        targetSdkVersion 26
+        versionName '1.1.2'
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-        versionCode 5
+        versionCode 6
     }
     dataBinding {
         enabled = true
@@ -29,7 +29,7 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.3.1'
+    compile 'com.android.support:appcompat-v7:26.0.0-alpha1'
     testCompile 'junit:junit:4.12'
     compile 'com.google.android.gms:play-services-appindexing:9.8.0'
     compile project(':pickdate')

--- a/app/src/main/res/layout/shoppinglist.xml
+++ b/app/src/main/res/layout/shoppinglist.xml
@@ -22,6 +22,7 @@
             android:id="@+id/shoppinglist_shopcity"
             style="@style/listviewrowcol_standard"
             android:layout_weight="74"
+            android:layout_height="@dimen/text_size_tiny"
             />
     </LinearLayout>
     <LinearLayout


### PR DESCRIPTION
Targetting chaned to target minSDK 14 up to 26.
Changed shoppinglidt ccity to use text_size_tiny rather than nothing.
Implemented bug fix for issue #117 DisplayHelp crashing on some devices due to casting to RelativeLayout instead of LinearLayout.

Also changed Version code from 5 to **6** and Version from 1.1.1 to **1.1.2**