### PR TITLE
Made changes to cater for Android (Pie) 9.0 +

### DIFF
--- a/app/src/main/java/mjt/shopwise/ActionColorCoding.java
+++ b/app/src/main/java/mjt/shopwise/ActionColorCoding.java
@@ -63,9 +63,9 @@ class ActionColorCoding {
     private static boolean colorsloaded = false;
     public static final String THISCLASS = ActionColorCoding.class.getSimpleName();
     /**
-     * The constant transparency_requied.
+     * The constant transparency_required.
      */
-    public static final int transparency_requied = 0x44ffffff;
+    public static final int transparency_required = 0x44ffffff;
     public static final int transparency_optional = 0x22ffffff;
     public static final int transparency_evenrow = 0x3fffffff;
     public static final int transparency_oddrow = 0x1fffffff;
@@ -374,7 +374,7 @@ class ActionColorCoding {
         h4.setBackgroundColor(setHeadingColor(passedoption,4));
 
         re.setBackgroundColor(setHeadingColor(passedoption,2) &
-                ActionColorCoding.transparency_requied);
+                ActionColorCoding.transparency_required);
         oe.setBackgroundColor(setHeadingColor(passedoption,4) &
                 ActionColorCoding.transparency_optional);
     }

--- a/app/src/main/java/mjt/shopwise/AdapterShopList.java
+++ b/app/src/main/java/mjt/shopwise/AdapterShopList.java
@@ -14,15 +14,13 @@ import android.widget.TextView;
  *                      Note has been written for ListView and Spinner
  *                      i.e. includes overridden getDropDownView method.
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({"WeakerAccess","SameParameterValue","UnusedParameters","CanBeFinal","unused"})
 class AdapterShopList extends CursorAdapter {
 
     private final Intent callerintent;
     private final Context ctxt;
     private final boolean fromspinner;
-    @SuppressWarnings("CanBeFinal")
     private boolean clickable;
-    @SuppressWarnings("CanBeFinal")
     private boolean longclickable;
     private Cursor cursor;
 
@@ -47,10 +45,9 @@ class AdapterShopList extends CursorAdapter {
      * @param intent        the intent, used for
      * @param fromspinner   true if used by a spinner
      */
-    @SuppressWarnings("SameParameterValue")
     AdapterShopList(Context context,
                     Cursor csr,
-                    @SuppressWarnings("UnusedParameters") int flags,
+                    int flags,
                     Intent intent,
                     boolean fromspinner,
                     boolean clickable,
@@ -106,7 +103,7 @@ class AdapterShopList extends CursorAdapter {
         String msg = "Invoked";
         String methodname = new Object(){}.getClass().getEnclosingMethod().getName();
         LogMsg.LogMsg(LogMsg.LOGTYPE_INFORMATIONAL,LOGTAG,msg,THISCLASS,methodname);
-        @SuppressWarnings("unused") int position = csr.getPosition();
+        int position = csr.getPosition();
         //noinspection UnusedAssignment
         view = initView(view, csr);
     }
@@ -202,9 +199,9 @@ class AdapterShopList extends CursorAdapter {
 
         String shopname = cursor.getString(shops_shopname_offest);
         String shopcity = cursor.getString(shops_shopcity_offset);
-        @SuppressWarnings("unused") String shopstreet = cursor.getString(shops_shopstreet_offset);
-        @SuppressWarnings("unused") String shopstate = cursor.getString(shops_shopstate_offset);
-        @SuppressWarnings("unused") String shopnotes = cursor.getString(shops_shopnotes_offset);
+        String shopstreet = cursor.getString(shops_shopstreet_offset);
+        String shopstate = cursor.getString(shops_shopstate_offset);
+        String shopnotes = cursor.getString(shops_shopnotes_offset);
         String shoporder = cursor.getString(shops_shoporder_offset);
 
         nametv.setText(shopname);

--- a/app/src/main/java/mjt/shopwise/AislesAddEditActivity.java
+++ b/app/src/main/java/mjt/shopwise/AislesAddEditActivity.java
@@ -21,7 +21,7 @@ import android.widget.TextView;
 
 import mjt.displayhelp.DisplayHelp;
 
-import static mjt.shopwise.ActionColorCoding.transparency_requied;
+import static mjt.shopwise.ActionColorCoding.transparency_required;
 
 import static mjt.sqlwords.SQLKWORD.*;
 
@@ -193,8 +193,8 @@ public class AislesAddEditActivity extends AppCompatActivity {
         h4 = ActionColorCoding.setHeadingColor(this,getIntent(),4);
         ActionColorCoding.setActionButtonColor(donebutton, primary_color);
         ActionColorCoding.setActionButtonColor(savebutton, primary_color);
-        ActionColorCoding.setActionButtonColor(input_aislename,h2 & transparency_requied);
-        ActionColorCoding.setActionButtonColor(input_aisleorder,h2 & transparency_requied);
+        ActionColorCoding.setActionButtonColor(input_aislename,h2 & transparency_required);
+        ActionColorCoding.setActionButtonColor(input_aisleorder,h2 & transparency_required);
         aislelist_heading_linearlayout.setBackgroundColor(h1);
         ActionColorCoding.setActionButtonColor(input_aisleshop_select,h2);
         input_aislename_label.setTextColor(primary_color);

--- a/app/src/main/java/mjt/shopwise/BackupActivity.java
+++ b/app/src/main/java/mjt/shopwise/BackupActivity.java
@@ -40,7 +40,7 @@ import mjt.displayhelp.DisplayHelp;
  */
 
 @SuppressWarnings({"FieldCanBeLocal", "WeakerAccess", "CanBeFinal", "unused"})
-public class BackupActivity extends AppCompatActivity {
+public class BackupActivity extends AppCompatActivity implements BackupActivityInterface {
 
     @SuppressWarnings("unused")
     private static final String THIS_ACTIVITY = "BackupActivity";
@@ -182,12 +182,12 @@ public class BackupActivity extends AppCompatActivity {
         h4 = ActionColorCoding.setHeadingColor(this,getIntent(),4);
         ActionColorCoding.setActionButtonColor(donebutton,primary_color);
         ActionColorCoding.setActionButtonColor(backupdatetimepart,
-                h2 & ActionColorCoding.transparency_requied);
+                h2 & ActionColorCoding.transparency_required);
         ActionColorCoding.setActionButtonColor(backupresetbutton,primary_color);
         ActionColorCoding.setActionButtonColor(backupbasepart,
-                h2 & ActionColorCoding.transparency_requied);
+                h2 & ActionColorCoding.transparency_required);
         ActionColorCoding.setActionButtonColor(backupextension,
-                h2 & ActionColorCoding.transparency_requied);
+                h2 & ActionColorCoding.transparency_required);
         backupfullfilename.setTextColor(Color.BLUE);
         ActionColorCoding.setActionButtonColor(backupbutton,primary_color);
         ActionColorCoding.setActionButtonColor(selectrestorefile,h4);
@@ -400,7 +400,8 @@ public class BackupActivity extends AppCompatActivity {
                     LogMsg.LogMsg(LogMsg.LOGTYPE_INFORMATIONAL,
                            BackupActivity.LOGTAG,"Copy Completed.",
                             BackupActivity.THISCLASS,methodname);
-                    populateAllSpinners();
+                    //populateAllSpinners(); Changed for ANDROID 9.0 can't change view added interface
+                    DatabaseSaved(); // CHANGED TO use Interface to update Spinners
                 }
                 catch (IOException e) {
                     String methodname = new Object(){}.getClass().getEnclosingMethod().getName();
@@ -578,6 +579,15 @@ public class BackupActivity extends AppCompatActivity {
                         msg = "Stage 2 - Completed. Original DB deleted.";
                         LogMsg.LogMsg(LogMsg.LOGTYPE_INFORMATIONAL,LOGTAG,msg,THISCLASS,methodname);
                         origdeleted = true;
+                        // Added for Android 9+ to delete shm and wal file if they exist
+                        File dbshm = new File(dbfile.getPath() + "-shm");
+                        File dbwal = new File(dbfile.getPath()+ "-wal");
+                        if (dbshm.exists()) {
+                            dbshm.delete();
+                        }
+                        if (dbwal.exists()) {
+                            dbwal.delete();
+                        }
                     }
 
                     // Stage 3 copy from the backup to the deleted database file i.e. create it
@@ -919,6 +929,10 @@ public class BackupActivity extends AppCompatActivity {
         }
         messagebar.setVisibility(View.VISIBLE);
         ba.actionbar.setTitle(getResources().getString(R.string.shopslabel));
+    }
+
+    public void DatabaseSaved() {
+        populateAllSpinners();
     }
 
 }

--- a/app/src/main/java/mjt/shopwise/BackupActivityInterface.java
+++ b/app/src/main/java/mjt/shopwise/BackupActivityInterface.java
@@ -1,0 +1,5 @@
+package mjt.shopwise;
+
+public interface BackupActivityInterface {
+    void DatabaseSaved();
+}

--- a/app/src/main/java/mjt/shopwise/ProductsAddEditActivity.java
+++ b/app/src/main/java/mjt/shopwise/ProductsAddEditActivity.java
@@ -24,7 +24,7 @@ import android.widget.TextView;
 import mjt.displayhelp.DisplayHelp;
 
 import static mjt.shopwise.ActionColorCoding.transparency_optional;
-import static mjt.shopwise.ActionColorCoding.transparency_requied;
+import static mjt.shopwise.ActionColorCoding.transparency_required;
 
 import static mjt.sqlwords.SQLKWORD.*;
 
@@ -219,9 +219,9 @@ public class ProductsAddEditActivity  extends AppCompatActivity {
         h4 = ActionColorCoding.setHeadingColor(this,getIntent(),4);
         ActionColorCoding.setActionButtonColor(donebutton, primary_color);
         ActionColorCoding.setActionButtonColor(savebutton, primary_color);
-        ActionColorCoding.setActionButtonColor(inputproductname,h2 & transparency_requied);
+        ActionColorCoding.setActionButtonColor(inputproductname,h2 & transparency_required);
         ActionColorCoding.setActionButtonColor(inputproductstorage_spinner,h2);
-        ActionColorCoding.setActionButtonColor(inputproductorder,h2 & transparency_requied);
+        ActionColorCoding.setActionButtonColor(inputproductorder,h2 & transparency_required);
         ActionColorCoding.setActionButtonColor(inputproductfilter,h4 & transparency_optional);
         productlistheading.setBackgroundColor(h1);
         inputproductname_label.setTextColor(primary_color);

--- a/app/src/main/java/mjt/shopwise/RuleToolsActivity.java
+++ b/app/src/main/java/mjt/shopwise/RuleToolsActivity.java
@@ -126,9 +126,9 @@ public class RuleToolsActivity extends AppCompatActivity{
         ActionColorCoding.setActionButtonColor(suggestbutton,primary_color);
         ActionColorCoding.setActionButtonColor(checkbutton,primary_color);
         ActionColorCoding.setActionButtonColor(minbuy,
-                h2 & ActionColorCoding.transparency_requied);
+                h2 & ActionColorCoding.transparency_required);
         ActionColorCoding.setActionButtonColor(minperiod,
-                h2 & ActionColorCoding.transparency_requied);
+                h2 & ActionColorCoding.transparency_required);
         suggestoverview.setTextColor(h2);
         checkoverview.setTextColor(h2);
         minbuylabel.setTextColor(primary_color);

--- a/app/src/main/java/mjt/shopwise/RulesAddEditActivity.java
+++ b/app/src/main/java/mjt/shopwise/RulesAddEditActivity.java
@@ -425,10 +425,10 @@ public class RulesAddEditActivity extends AppCompatActivity {
                 h2 & ActionColorCoding.transparency_optional);
         rulenamelabel.setTextColor(primary_color);
         ActionColorCoding.setActionButtonColor(rulename_input,
-                h2 & ActionColorCoding.transparency_requied);
+                h2 & ActionColorCoding.transparency_required);
         numbertogetlabel.setTextColor(primary_color);
         ActionColorCoding.setActionButtonColor(numbertoget_input,
-                h2 & ActionColorCoding.transparency_requied);
+                h2 & ActionColorCoding.transparency_required);
         rulepromptlabel.setTextColor(primary_color);
         ActionColorCoding.setActionButtonColor(ruleprompt_input,
                 h2 & ActionColorCoding.transparency_optional);
@@ -439,10 +439,10 @@ public class RulesAddEditActivity extends AppCompatActivity {
                 ActionColorCoding.transparency_optional);
         ruleperiodlabel.setTextColor(primary_color);
         ActionColorCoding.setActionButtonColor(ruleperiod_input,
-                h2 & ActionColorCoding.transparency_requied);
+                h2 & ActionColorCoding.transparency_required);
         rulemultiplierlabel.setTextColor(primary_color);
         ActionColorCoding.setActionButtonColor(rulemultiplier_input,
-                h2 & ActionColorCoding.transparency_requied);
+                h2 & ActionColorCoding.transparency_required);
         ActionColorCoding.setActionButtonColor(ruleperiod_input, h2);
         rulelistheading.setBackgroundColor(h1);
         sortable.setTextColor(primary_color);

--- a/app/src/main/java/mjt/shopwise/ShoppingEntryAdjustActivity.java
+++ b/app/src/main/java/mjt/shopwise/ShoppingEntryAdjustActivity.java
@@ -322,7 +322,7 @@ public class ShoppingEntryAdjustActivity extends AppCompatActivity {
         ActionColorCoding.setActionButtonColor(undobutton,primary_color);
         originalvaluesheading.setBackgroundColor(h1);
         int etbgcol = ActionColorCoding.getGroupColor(passedmenucolorcode,3)
-                & ActionColorCoding.transparency_requied;
+                & ActionColorCoding.transparency_required;
         int bgcol = ActionColorCoding.getGroupColor(passedmenucolorcode,3) &
                 ActionColorCoding.transparency_optional;
         orig_productname_tv.setTextColor(primary_color);

--- a/app/src/main/java/mjt/shopwise/ShopsAddEditActivity.java
+++ b/app/src/main/java/mjt/shopwise/ShopsAddEditActivity.java
@@ -20,7 +20,7 @@ import android.widget.TextView;
 import mjt.displayhelp.DisplayHelp;
 
 import static mjt.shopwise.ActionColorCoding.transparency_optional;
-import static mjt.shopwise.ActionColorCoding.transparency_requied;
+import static mjt.shopwise.ActionColorCoding.transparency_required;
 
 import static mjt.sqlwords.SQLKWORD.*;
 
@@ -196,9 +196,9 @@ public class ShopsAddEditActivity extends AppCompatActivity {
         h4 = ActionColorCoding.setHeadingColor(this,getIntent(),4);
         ActionColorCoding.setActionButtonColor(donebutton, primary_color);
         ActionColorCoding.setActionButtonColor(savebutton, primary_color);
-        ActionColorCoding.setActionButtonColor(inputshopname,h2 & transparency_requied);
+        ActionColorCoding.setActionButtonColor(inputshopname,h2 & transparency_required);
         ActionColorCoding.setActionButtonColor(inputshopcity,h4 & transparency_optional);
-        ActionColorCoding.setActionButtonColor(inputshoporder,h2 & transparency_requied);
+        ActionColorCoding.setActionButtonColor(inputshoporder,h2 & transparency_required);
         inputshopname_label.setTextColor(primary_color);
         inputshopcity_label.setTextColor(h1);
         inputshoporder_label.setTextColor(h1);

--- a/app/src/main/java/mjt/shopwise/StockAddActivity.java
+++ b/app/src/main/java/mjt/shopwise/StockAddActivity.java
@@ -319,9 +319,9 @@ public class StockAddActivity extends AppCompatActivity {
         ActionColorCoding.setActionButtonColor(inputproductfilter,
                 h2 & ActionColorCoding.transparency_optional);
         ActionColorCoding.setActionButtonColor(inputstockcost,
-                h2 & ActionColorCoding.transparency_requied);
+                h2 & ActionColorCoding.transparency_required);
         ActionColorCoding.setActionButtonColor(inputstockorder,
-                h2 & ActionColorCoding.transparency_requied);
+                h2 & ActionColorCoding.transparency_required);
         ActionColorCoding.setActionButtonColor(inputchecklistcount,
                 h2 & ActionColorCoding.transparency_optional);
         ActionColorCoding.setActionButtonColor(inputchecklistflag,

--- a/app/src/main/java/mjt/shopwise/StockEditActivity.java
+++ b/app/src/main/java/mjt/shopwise/StockEditActivity.java
@@ -268,11 +268,11 @@ public class StockEditActivity extends AppCompatActivity {
         ActionColorCoding.setActionButtonColor(donebutton,primary_color);
         ActionColorCoding.setActionButtonColor(savebutton,primary_color);
         ActionColorCoding.setActionButtonColor(productname,
-                h2 & ActionColorCoding.transparency_requied);
+                h2 & ActionColorCoding.transparency_required);
         ActionColorCoding.setActionButtonColor(inputstockcost,
-                h2 & ActionColorCoding.transparency_requied);
+                h2 & ActionColorCoding.transparency_required);
         ActionColorCoding.setActionButtonColor(inputstockorder,
-                h2 & ActionColorCoding.transparency_requied);
+                h2 & ActionColorCoding.transparency_required);
         ActionColorCoding.setActionButtonColor(inputchecklistcount,
                 h2 & ActionColorCoding.transparency_optional);
         ActionColorCoding.setActionButtonColor(inputchecklistflag,

--- a/app/src/main/java/mjt/shopwise/StorageAddEditActivity.java
+++ b/app/src/main/java/mjt/shopwise/StorageAddEditActivity.java
@@ -19,7 +19,7 @@ import android.widget.TextView;
 
 import mjt.displayhelp.DisplayHelp;
 
-import static mjt.shopwise.ActionColorCoding.transparency_requied;
+import static mjt.shopwise.ActionColorCoding.transparency_required;
 
 import static mjt.sqlwords.SQLKWORD.*;
 
@@ -194,9 +194,9 @@ public class StorageAddEditActivity extends AppCompatActivity {
         ActionColorCoding.setActionButtonColor(donebutton, primary_color);
         ActionColorCoding.setActionButtonColor(savebutton, primary_color);
         ActionColorCoding.setActionButtonColor(inputstoragename,
-                h2 & transparency_requied);
+                h2 & transparency_required);
         ActionColorCoding.setActionButtonColor(inputstorageorder,
-                h2 & transparency_requied);
+                h2 & transparency_required);
         inputstoragename_label.setTextColor(h1);
         inputstorageorder_label.setTextColor(h1);
         storagelist_heading.setBackgroundColor(h1);


### PR DESCRIPTION
As Android Pie uses SQLite Write-Ahead Logging (WAL) rather than journal mode will now delete -wal and -shm files when restoring a database.
Additionally Views cannot be updated from outside main UI thread, so when backing up DB an interface (BackupActivityInterface) is used to now
invoke the spinner updates on the UI thread.